### PR TITLE
Shared and static library target, DLL symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(LIBRARY_SOURCES
     lav.cpp
     lavertex.cpp
-    polyskel.cpp
     slav.cpp
     util.cpp
+    polyskel.cpp
 )
 
 # Add header files (not necessary for the build, but useful for IDEs)
@@ -29,12 +29,18 @@ set(LIBRARY_HEADERS
 file(COPY ${CMAKE_SOURCE_DIR}/test DESTINATION ${CMAKE_BINARY_DIR})
 file(COPY ${CMAKE_SOURCE_DIR}/examples DESTINATION ${CMAKE_BINARY_DIR})
 
+# Add the executable
+add_executable(demo demo.cpp)
 
 # Create the shared library
 add_library(polyskel SHARED ${LIBRARY_SOURCES})
 
-# Add the executable
-add_executable(demo demo.cpp)
+get_target_property(polyskel_target_type polyskel TYPE)
+if(polyskel_target_type STREQUAL STATIC_LIBRARY)
+  target_compile_definitions(polyskel PUBLIC POLYSKEL_STATIC_EXPORTS)
+else()
+  target_compile_definitions(polyskel PRIVATE POLYSKEL_SHARED_EXPORTS)
+endif()
 
 # Link the shared library to the executable
 target_link_libraries(demo polyskel)

--- a/lavertex.h
+++ b/lavertex.h
@@ -17,7 +17,7 @@ struct OriginalEdge {
         : edge(edge), bisector_left(bisector_left), bisector_right(bisector_right) {}
 };
 
-struct Subtree {
+struct POLYSKEL_DLL_SYMBOL Subtree {
     Vec2 source;
     double height;
     vector<Vec2> sinks;

--- a/polyskel.cpp
+++ b/polyskel.cpp
@@ -18,6 +18,7 @@
 #include "event.h"
 #include "slav.h"
 #include "lav.h"
+#include "polyskel.h"
 
 
 using namespace std;
@@ -26,7 +27,7 @@ void _merge_sources(vector<shared_ptr<Subtree>>& skeleton) {
     unordered_map<Vec2, unsigned int, vec2hash> sources;
     vector<unsigned int> to_remove;
 
-    for (size_t i = 0; i < skeleton.size(); i++) {
+    for (unsigned int i = 0; i < skeleton.size(); i++) {
         Subtree& p = *skeleton[i]; 
         Vec2 source = p.source;
         if (sources.find(source) != sources.end()) {
@@ -43,7 +44,7 @@ void _merge_sources(vector<shared_ptr<Subtree>>& skeleton) {
         }
     }
 
-    for (int i = to_remove.size() - 1; i >= 0; i--) {
+    for (int i = static_cast<int>(to_remove.size()) - 1; i >= 0; i--) {
         skeleton.erase(skeleton.begin() + to_remove[i]);
     }
 }
@@ -95,6 +96,6 @@ vector<shared_ptr<Subtree>> skeletonize(vector<Vec2>& polygon, vector<vector<Vec
     }
 
     _merge_sources(output);
+    
     return output;
-
 }

--- a/polyskel.h
+++ b/polyskel.h
@@ -2,12 +2,13 @@
 #define POLYSKEL_H
 
 #include <vector>
+#include "util.h"
 #include "vec.h"
 
 using namespace std;
 
-class Subtree;
+struct Subtree;
 
-vector<shared_ptr<Subtree>> skeletonize(vector<Vec2>& polygon, vector<vector<Vec2>>& holes);
+POLYSKEL_DLL_SYMBOL vector<shared_ptr<Subtree>> skeletonize(vector<Vec2>& polygon, vector<vector<Vec2>>& holes);
 
 #endif //POLYSKEL_H

--- a/slav.h
+++ b/slav.h
@@ -3,12 +3,14 @@
 
 #include <memory>
 #include <vector>
+#include <utility>
 
 #include "vec.h"
+#include "event.h"
 
+struct OriginalEdge;
+struct Subtree;
 class LAV;
-class OriginalEdge;
-class Subtree;
 class Event;
 class EdgeEvent;
 class SplitEvent;

--- a/util.h
+++ b/util.h
@@ -12,8 +12,30 @@
 
 #define EPSILON 0.00001
 
-class Vec2;
-class Edge;
+#if defined(_WIN32)
+#  define POLYSKEL_COMPILER_DLLEXPORT __declspec(dllexport)
+#  define POLYSKEL_COMPILER_DLLIMPORT __declspec(dllimport)
+#elif defined(__GNUC__)
+#  define POLYSKEL_COMPILER_DLLEXPORT __attribute__ ((visibility ("default")))
+#  define POLYSKEL_COMPILER_DLLIMPORT __attribute__ ((visibility ("default")))
+#else
+#  define POLYSKEL_COMPILER_DLLEXPORT
+#  define POLYSKEL_COMPILER_DLLIMPORT
+#endif
+
+#ifndef POLYSKEL_DLL_SYMBOL
+#  if defined(POLYSKEL_STATIC_EXPORTS)
+#    define POLYSKEL_DLL_SYMBOL
+#  elif defined(POLYSKEL_SHARED_EXPORTS)
+#    define POLYSKEL_DLL_SYMBOL POLYSKEL_COMPILER_DLLEXPORT
+#  else
+#    define POLYSKEL_DLL_SYMBOL POLYSKEL_COMPILER_DLLIMPORT
+#  endif
+#endif
+
+
+struct Vec2;
+struct Edge;
 
 using namespace std;
 
@@ -52,6 +74,6 @@ unique_ptr<Vec2> intersect(const Edge& l1, const Edge& l2, char type1 = 'l', cha
 
 Edge get_creator_vectors(const Edge& e_left, const Edge& e_right);
 
-bool approximately_equals(double lhs, double rhs);
+POLYSKEL_DLL_SYMBOL bool approximately_equals(double lhs, double rhs);
 
 #endif // UTIL_H

--- a/vec.h
+++ b/vec.h
@@ -9,7 +9,7 @@
 
 using namespace std;
 
-struct Vec2 {
+struct POLYSKEL_DLL_SYMBOL Vec2 {
     double x;
     double y;
 


### PR DESCRIPTION
Fixed compilation on Windows MSVC.
You can now successfully build the library as DLL with the skeletonize function exported.